### PR TITLE
Add install class

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ root@puppet-server:~ service puppetserver restart
 Contents of `/etc/puppetlabs/code/environments/production/manifests/site.pp`
 ```puppet
 node 'proxy-agent.example.com' {
+  include cisco_aci
   puppet_device {'apic.example.com':
     type             => 'apic',  # Specifies the type of the device in device.conf.
     url              => 'https://username:password@apic.example.com', # Specifies the URL of the device in device.conf.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -42,7 +42,7 @@
 #
 # Copyright 2018 Your name here, unless otherwise noted.
 #
-class aci_puppet_module {
-
+class cisco_aci {
+  class { 'cisco_aci::install': }
 
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,0 +1,20 @@
+# Private class
+class cisco_aci::install {
+  $gems = [ 'httpclient', 'nokogiri' ]
+
+  package { $gems:
+    ensure   => present,
+    provider => 'puppet_gem',
+  }
+
+  case $::operatingsystem {
+    'CentOS': {
+      $packages = [ 'gcc', 'zlib-devel' ]
+
+      package { $packages:
+        ensure  => present,
+        before  => Package['nokogiri'],
+      }
+    }
+  }
+}


### PR DESCRIPTION
The module requires gems not included by default in puppet-agent

This creates an install class with the required packages for CentOS.  Other supported operating systems should also be added.