### PR TITLE
Begin linting with PDK

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,9 @@ gem 'puppet', puppetversion
 facterversion = ENV.key?('FACTER_GEM_VERSION') ? "#{ENV['FACTER_GEM__VERSION']}" : ['>= 1.7.0']
 gem 'facter', '>= 1.7.0'
 
+ruby_version_segments = Gem::Version.new(RUBY_VERSION.dup).segments
+minor_version = ruby_version_segments[0..1].join('.')
+
 group :development, :acceptance_tests do
   gem 'rake',                    require: false
   gem 'rspec',                   require: false
@@ -48,4 +51,6 @@ group :development, :acceptance_tests do
   gem 'rubocop', '= 0.35.1',     require: false
   gem 'simplecov',               require: false
   gem 'puppet-blacksmith', '~> 3.4', require: false
+  gem "puppet-module-posix-default-r#{minor_version}", require: false, platforms: [:ruby]
+  gem "puppet-module-posix-dev-r#{minor_version}",     require: false, platforms: [:ruby]
 end

--- a/metadata.json
+++ b/metadata.json
@@ -10,13 +10,9 @@
   "dependencies": [
     {
       "name": "tkishel/puppet_device",
-      "version_requirement": ">= 2.4.4" }
+      "version_requirement": ">= 2.4.4 < 3.0.0" }
   ],
   "requirements": [
-    {
-      "name": "pe",
-      "version_requirement": ">= 2017.3"
-    },
     {
       "name": "puppet",
       "version_requirement": ">= 5.5"


### PR DESCRIPTION
Added gems needed for `pdk validate` and cleaned up metadata.
https://puppet.com/docs/pdk/1.x/pdk_testing.html

There are 750+ puppet-lint / rubocop violations in the module that may affect the code quality score.
https://gist.github.com/shermdog/4c5c464467d334ea7badfc5dd3ecabef

May want to consider using `pdk convert` to bring module template in line with ours.
https://puppet.com/blog/guide-converting-module-pdk
https://puppet.com/docs/pdk/1.x/pdk_converting_modules.html

Note on removing PE version from metadata
https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/puppet-users/nkRPvG4q0Oo/GmXa109aJQAJ