### PR TITLE
[WIP] Fix for Unable to query cisco_aci_fvsubnet

### DIFF
--- a/lib/puppet/provider/cisco_aci_fvsubnet/cisco_aci.rb
+++ b/lib/puppet/provider/cisco_aci_fvsubnet/cisco_aci.rb
@@ -92,7 +92,6 @@ Puppet::Type.type(:cisco_aci_fvsubnet).provide(:cisco_aci) do
     [
         :ctrl,
         :descr,
-        :name,
         :name_alias,
         :preferred,
         :scope,
@@ -107,7 +106,6 @@ Puppet::Type.type(:cisco_aci_fvsubnet).provide(:cisco_aci) do
         :descr => 'descr',
         :dn => 'dn',
         :ip => 'ip',
-        :name => 'name',
         :name_alias => 'nameAlias',
         :preferred => 'preferred',
         :scope => 'scope',
@@ -184,6 +182,4 @@ Puppet::Type.type(:cisco_aci_fvsubnet).provide(:cisco_aci) do
   end
 
   mk_resource_methods_custom_setters
-
-
 end

--- a/lib/puppet/type/cisco_aci_fvsubnet.rb
+++ b/lib/puppet/type/cisco_aci_fvsubnet.rb
@@ -35,7 +35,7 @@ Puppet::Type.newtype(:cisco_aci_fvsubnet) do
     patterns << [
       /^(\S+)$/,
       [
-        [:name, identity]
+        [:ip, identity]
       ],
     ]
     patterns
@@ -44,6 +44,10 @@ Puppet::Type.newtype(:cisco_aci_fvsubnet) do
   # ---------------------------------------------------------------
   # Namevars (Instance Identifiers)
   # ---------------------------------------------------------------
+
+  #Only needed to satisfy name parameter.
+  newparam(:name) do
+  end
 
   newparam(:ip, namevar: true) do
     desc "https://pubhub.devnetcloud.com/media/apic-mim-ref-311/docs/MO-fvSubnet.html#ip"
@@ -73,10 +77,6 @@ Puppet::Type.newtype(:cisco_aci_fvsubnet) do
 
   newproperty(:descr) do
     desc "https://pubhub.devnetcloud.com/media/apic-mim-ref-311/docs/MO-fvSubnet.html#descr"
-  end
-
-  newproperty(:name) do
-    desc "https://pubhub.devnetcloud.com/media/apic-mim-ref-311/docs/MO-fvSubnet.html#name"
   end
 
   newproperty(:name_alias) do

--- a/lib/puppet_x/cisco/aci_provider_utils.rb
+++ b/lib/puppet_x/cisco/aci_provider_utils.rb
@@ -208,8 +208,10 @@ module PuppetX
           instance_array = []
           mos = Puppet::Util::NetworkDevice.current.get(
                                           provider_class.mo_class_query_url)
+          namevar = provider_class.my_namevars[0]
           mos['imdata'].each do |mo|
             pt_attr_hash = self.xtract_attr_hash_frm_json(mo,provider_class)
+            pt_attr_hash.update({:name => pt_attr_hash[namevar]})
             pt_attr_hash.update({:ensure => :present})
             instance_array << provider_class.new(pt_attr_hash)
           end


### PR DESCRIPTION
This PR fixes https://github.com/cisco/ciscoacipuppet/issues/2

This problem is caused by the fact that the `name` information returned by the APIC for `cisco_aci_fvsubnet`  is always an empty string.

This fix does the following.

1) Removes `name` as a property
2) Creates a parameter `name` that is not a namevar but can be used to map `ip` into `name`.
3) Uses `ip` in the title pattern for resource discovery.

**Testing:***

The following manifest is used for testing.

```puppet
node 'proxyagent.example.com' {
  puppet_device {'apic.example.com':
    type             => 'apic',  # Specifies the type of the device in device.conf.
    url              => 'https://admin:password@apic.example.com', # Specifies the URL of the device in device.conf.
    #run_interval     =>  30,     # Execute `puppet device --target apic.example.com` every 30 minutes.
  }
}

node 'apic.example.com' {

  cisco_aci_fvtenant {'test_tenant1':
    ensure => 'present',
    name   => 'test_tenant1',
    descr  => 'My test tenant',
  }
  cisco_aci_fvap { 'test_app1':
    ensure   => 'present',
    name     => 'test_app1',    # Instance Identifier
    fvtenant => 'test_tenant1', # Parent cisco_aci_fvtenant Identifier
    descr    => 'My test application profile tenant test_tenant1',
  }
  cisco_aci_fvaepg { 'test_epg1':
    ensure    => 'present',
    name      => 'test_epg1',    # Instance Identifier
    fvtenant  => 'test_tenant1', # Parent cisco_aci_fvtenant Identifier
    fvap      => 'test_app1',    # Parent cisco_aci_fvap Identifier
    descr     => 'My EPF test_epg1 in the application profile test_app1 in tenant test_tenant1',
  }
  cisco_aci_fvbd { 'test_bd1':
    ensure    => 'present',
    name      => 'test_bd1',     # Instance Identifier
    fvtenant  => 'test_tenant1', # Parent cisco_aci_fvtenant Identifier
    descr     => 'My bridge domain in tenant test_tenant1',
  }
  cisco_aci_fvctx { 'test_vrf1':
    ensure    => 'present',
    name      => 'test_vrf1',    # Instance Identifier
    fvtenant  => 'test_tenant1', # Parent cisco_aci_fvtenant Identifier
    descr     => 'My VRF context in tenant test_tenant1',
  }
  cisco_aci_fvsubnet { 'subnet1':
    ensure    => 'present',
    ip        => '20.20.20.3/24', # Instance Identifier
    fvtenant  => 'test_tenant1',  # Parent cisco_aci_fvtenant Identifier
    fvbd      => 'test_bd1',      # Parent cisco_aci_fvbd Identifier
    descr     => 'My subnet subnet1 in bridge domain test_bd1 in tenant test_tenant1',
  }
  cisco_aci_vzbrcp { 'test_contract1':
    ensure    => 'present',
    name      => 'test_contract1', # Instance Identifier
    fvtenant  => 'test_tenant1',   # Parent cisco_aci_fvtenant Identifier
    descr     => 'My contract test_contract1 on my tenant test_tenant1',
  }
  cisco_aci_vzfilter { 'test_filter1':
    ensure    => 'present',
    name      => 'test_filter1', # Instance Identifier
    fvtenant  => 'test_tenant1', # Parent cisco_aci_fvtenant Identifier
    descr     => 'My filter test_filter1',
  }
  cisco_aci_vzsubj { 'test_subject1':
    ensure    => 'present',
    name      => 'test_subject1',  # Instance Identifier
    fvtenant  => 'test_tenant1',   # Parent cisco_aci_fvtenant Identifier
    vzbrcp    => 'test_contract1', # Parent cisco_aci_vzbrcp Identifier
    descr     => 'My subject test_subject1 for contract test_contract1 in tenant test_tenant1',
  }
  cisco_aci_vzentry { 'test_filter_entry1':
    ensure    => 'present',
    name      => 'test_filter_entry1', # Instance Identifier
    fvtenant  => 'test_tenant1',       # Parent cisco_aci_fvtenant Identifier
    vzfilter  => 'test_filter1',       # Parent cisco_aci_vzfilter Identifier
    descr     => 'My filter entry test_filter_entry1 for filter test_filter1 in tenant test_tenant1',
  }
  # Explicitly declare resources relationships.
  Cisco_aci_fvtenant['test_tenant1'] ->
  Cisco_aci_fvap['test_app1'] ->
  Cisco_aci_fvaepg['test_epg1'] ->
  Cisco_aci_fvbd['test_bd1'] ->
  Cisco_aci_fvctx['test_vrf1'] ->
  Cisco_aci_fvsubnet['subnet1'] ->
  Cisco_aci_vzbrcp['test_contract1'] ->
  Cisco_aci_vzfilter['test_filter1'] ->
  Cisco_aci_vzsubj['test_subject1'] ->
  Cisco_aci_vzentry['test_filter_entry1']

}
```

**1) Make present test**
```puppet
puppet device --verbose
Initiating authentication with APIC
Info: starting applying configuration to apic.example.com at https://apic.example.com:443
Info: Using configured environment 'production'
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Retrieving locales
Info: Caching catalog for apic.example.com
Info: Applying configuration version '1525371147'
Notice: /Stage[main]/Main/Node[apic.example.com]/Cisco_aci_fvtenant[test_tenant1]/ensure: created
Changed 'descr' from= '' to= 'My test tenant' 
Changed 'dn' from= '' to= 'uni/tn-test_tenant1' 
Changed 'name' from= '' to= 'test_tenant1' 
Changed 'name_alias' from= '' to= '' 
Changed 'owner_key' from= '' to= '' 
Changed 'owner_tag' from= '' to= '' 
Notice: /Stage[main]/Main/Node[apic.example.com]/Cisco_aci_fvap[test_app1]/ensure: created
Changed 'descr' from= '' to= 'My test application profile tenant test_tenant1' 
Changed 'dn' from= '' to= 'uni/tn-test_tenant1/ap-test_app1' 
Changed 'name' from= '' to= 'test_app1' 
Changed 'name_alias' from= '' to= '' 
Changed 'owner_key' from= '' to= '' 
Changed 'owner_tag' from= '' to= '' 
Changed 'prio' from= '' to= 'unspecified' 
Changed 'fvtenant' from= '' to= 'test_tenant1' 
Notice: Cisco_aci_fvap[test_app1](provider=cisco_aci): APIC GUI URI for provisioned resource https://apic.example.com/#bTenants:test_tenant1|uni/tn-test_tenant1/ap-[test_app1]
Notice: /Stage[main]/Main/Node[apic.example.com]/Cisco_aci_fvaepg[test_epg1]/ensure: created
Changed 'descr' from= '' to= 'My EPF test_epg1 in the application profile test_app1 in tenant test_tenant1' 
Changed 'dn' from= '' to= 'uni/tn-test_tenant1/ap-test_app1/epg-test_epg1' 
Changed 'fwd_ctrl' from= '' to= '' 
Changed 'is_attr_based_e_pg' from= '' to= 'no' 
Changed 'match_t' from= '' to= 'AtleastOne' 
Changed 'name' from= '' to= 'test_epg1' 
Changed 'name_alias' from= '' to= '' 
Changed 'pc_enf_pref' from= '' to= 'unenforced' 
Changed 'pref_gr_memb' from= '' to= 'exclude' 
Changed 'prio' from= '' to= 'unspecified' 
Changed 'fvtenant' from= '' to= 'test_tenant1' 
Changed 'fvap' from= '' to= 'test_app1' 
Notice: Cisco_aci_fvaepg[test_epg1](provider=cisco_aci): APIC GUI URI for provisioned resource https://apic.example.com/#bTenants:test_tenant1|uni/tn-test_tenant1/ap-test_app1/epg-[test_epg1]
Notice: /Stage[main]/Main/Node[apic.example.com]/Cisco_aci_fvbd[test_bd1]/ensure: created
Changed 'arp_flood' from= '' to= 'no' 
Changed 'descr' from= '' to= 'My bridge domain in tenant test_tenant1' 
Changed 'dn' from= '' to= 'uni/tn-test_tenant1/BD-test_bd1' 
Changed 'ep_clear' from= '' to= 'no' 
Changed 'ep_move_detect_mode' from= '' to= '' 
Changed 'intersite_bum_traffic_allow' from= '' to= 'no' 
Changed 'intersite_l2_stretch' from= '' to= 'no' 
Changed 'ip_learning' from= '' to= 'yes' 
Changed 'limit_ip_learn_to_subnets' from= '' to= 'yes' 
Changed 'll_addr' from= '' to= '0.0.0.0' 
Changed 'mac' from= '' to= '00:22:BD:F8:19:FF' 
Changed 'mcast_allow' from= '' to= 'no' 
Changed 'multi_dst_pkt_act' from= '' to= 'bd-flood' 
Changed 'name' from= '' to= 'test_bd1' 
Changed 'name_alias' from= '' to= '' 
Changed 'optimize_wan_bandwidth' from= '' to= 'no' 
Changed 'owner_key' from= '' to= '' 
Changed 'owner_tag' from= '' to= '' 
Changed 'type' from= '' to= 'regular' 
Changed 'unicast_route' from= '' to= 'yes' 
Changed 'unk_mac_ucast_act' from= '' to= 'proxy' 
Changed 'unk_mcast_act' from= '' to= 'flood' 
Changed 'vmac' from= '' to= 'not-applicable' 
Changed 'fvtenant' from= '' to= 'test_tenant1' 
Notice: Cisco_aci_fvbd[test_bd1](provider=cisco_aci): APIC GUI URI for provisioned resource https://apic.example.com/#bTenants:test_tenant1|uni/tn-test_tenant1/BD-[test_bd1]
Notice: /Stage[main]/Main/Node[apic.example.com]/Cisco_aci_fvctx[test_vrf1]/ensure: created
Changed 'bd_enforced_enable' from= '' to= 'no' 
Changed 'descr' from= '' to= 'My VRF context in tenant test_tenant1' 
Changed 'dn' from= '' to= 'uni/tn-test_tenant1/ctx-test_vrf1' 
Changed 'knw_mcast_act' from= '' to= 'permit' 
Changed 'name' from= '' to= 'test_vrf1' 
Changed 'name_alias' from= '' to= '' 
Changed 'owner_key' from= '' to= '' 
Changed 'owner_tag' from= '' to= '' 
Changed 'pc_enf_dir' from= '' to= 'ingress' 
Changed 'pc_enf_pref' from= '' to= 'enforced' 
Changed 'fvtenant' from= '' to= 'test_tenant1' 
Notice: Cisco_aci_fvctx[test_vrf1](provider=cisco_aci): APIC GUI URI for provisioned resource https://apic.example.com/#bTenants:test_tenant1|uni/tn-test_tenant1/ctx-[test_vrf1]
Notice: /Stage[main]/Main/Node[apic.example.com]/Cisco_aci_fvsubnet[subnet1]/ensure: created
Changed 'ctrl' from= '' to= 'nd' 
Changed 'descr' from= '' to= 'My subnet subnet1 in bridge domain test_bd1 in tenant test_tenant1' 
Changed 'dn' from= '' to= 'uni/tn-test_tenant1/BD-test_bd1/subnet-[20.20.20.3/24]' 
Changed 'ip' from= '' to= '20.20.20.3/24' 
Changed 'name_alias' from= '' to= '' 
Changed 'preferred' from= '' to= 'no' 
Changed 'scope' from= '' to= 'private' 
Changed 'virtual' from= '' to= 'no' 
Changed 'fvtenant' from= '' to= 'test_tenant1' 
Changed 'fvbd' from= '' to= 'test_bd1' 
Notice: Cisco_aci_fvsubnet[subnet1](provider=cisco_aci): APIC GUI URI for provisioned resource https://apic.example.com/#bTenants:test_tenant1|uni/tn-test_tenant1/BD-test_bd1/subnet-[20.20.20.3/24]
Notice: /Stage[main]/Main/Node[apic.example.com]/Cisco_aci_vzbrcp[test_contract1]/ensure: created
Changed 'descr' from= '' to= 'My contract test_contract1 on my tenant test_tenant1' 
Changed 'dn' from= '' to= 'uni/tn-test_tenant1/brc-test_contract1' 
Changed 'name' from= '' to= 'test_contract1' 
Changed 'name_alias' from= '' to= '' 
Changed 'owner_key' from= '' to= '' 
Changed 'owner_tag' from= '' to= '' 
Changed 'prio' from= '' to= 'unspecified' 
Changed 'scope' from= '' to= 'context' 
Changed 'target_dscp' from= '' to= 'unspecified' 
Changed 'fvtenant' from= '' to= 'test_tenant1' 
Notice: Cisco_aci_vzbrcp[test_contract1](provider=cisco_aci): APIC GUI URI for provisioned resource https://apic.example.com/#bTenants:test_tenant1|uni/tn-test_tenant1/brc-[test_contract1]
Notice: /Stage[main]/Main/Node[apic.example.com]/Cisco_aci_vzfilter[test_filter1]/ensure: created
Changed 'descr' from= '' to= 'My filter test_filter1' 
Changed 'dn' from= '' to= 'uni/tn-test_tenant1/flt-test_filter1' 
Changed 'name' from= '' to= 'test_filter1' 
Changed 'name_alias' from= '' to= '' 
Changed 'owner_key' from= '' to= '' 
Changed 'owner_tag' from= '' to= '' 
Changed 'fvtenant' from= '' to= 'test_tenant1' 
Notice: Cisco_aci_vzfilter[test_filter1](provider=cisco_aci): APIC GUI URI for provisioned resource https://apic.example.com/#bTenants:test_tenant1|uni/tn-test_tenant1/flt-[test_filter1]
Notice: /Stage[main]/Main/Node[apic.example.com]/Cisco_aci_vzsubj[test_subject1]/ensure: created
Changed 'cons_match_t' from= '' to= 'AtleastOne' 
Changed 'descr' from= '' to= 'My subject test_subject1 for contract test_contract1 in tenant test_tenant1' 
Changed 'dn' from= '' to= 'uni/tn-test_tenant1/brc-test_contract1/subj-test_subject1' 
Changed 'name' from= '' to= 'test_subject1' 
Changed 'name_alias' from= '' to= '' 
Changed 'prio' from= '' to= 'unspecified' 
Changed 'prov_match_t' from= '' to= 'AtleastOne' 
Changed 'rev_flt_ports' from= '' to= 'yes' 
Changed 'target_dscp' from= '' to= 'unspecified' 
Changed 'fvtenant' from= '' to= 'test_tenant1' 
Changed 'vzbrcp' from= '' to= 'test_contract1' 
Notice: Cisco_aci_vzsubj[test_subject1](provider=cisco_aci): APIC GUI URI for provisioned resource https://apic.example.com/#bTenants:test_tenant1|uni/tn-test_tenant1/brc-test_contract1/subj-[test_subject1]
Notice: /Stage[main]/Main/Node[apic.example.com]/Cisco_aci_vzentry[test_filter_entry1]/ensure: created
Changed 'apply_to_frag' from= '' to= 'no' 
Changed 'arp_opc' from= '' to= 'unspecified' 
Changed 'd_from_port' from= '' to= 'unspecified' 
Changed 'd_to_port' from= '' to= 'unspecified' 
Changed 'descr' from= '' to= 'My filter entry test_filter_entry1 for filter test_filter1 in tenant test_tenant1' 
Changed 'dn' from= '' to= 'uni/tn-test_tenant1/flt-test_filter1/e-test_filter_entry1' 
Changed 'ether_t' from= '' to= 'unspecified' 
Changed 'icmpv4_t' from= '' to= 'unspecified' 
Changed 'icmpv6_t' from= '' to= 'unspecified' 
Changed 'match_dscp' from= '' to= 'unspecified' 
Changed 'name' from= '' to= 'test_filter_entry1' 
Changed 'name_alias' from= '' to= '' 
Changed 'prot' from= '' to= 'unspecified' 
Changed 's_from_port' from= '' to= 'unspecified' 
Changed 's_to_port' from= '' to= 'unspecified' 
Changed 'stateful' from= '' to= 'no' 
Changed 'tcp_rules' from= '' to= '' 
Changed 'fvtenant' from= '' to= 'test_tenant1' 
Changed 'vzfilter' from= '' to= 'test_filter1' 
Notice: Cisco_aci_vzentry[test_filter_entry1](provider=cisco_aci): APIC GUI URI for provisioned resource https://apic.example.com/#bTenants:test_tenant1|uni/tn-test_tenant1/flt-test_filter1/e-[test_filter_entry1]
Info: Node[apic.example.com]: Unscheduling all events on Node[apic.example.com]
Notice: Applied catalog in 12.96 seconds
```

```puppet
puppet device --target apic.example.com --resource cisco_aci_fvsubnet '20.20.20.3/24'
Initiating authentication with APIC
cisco_aci_fvsubnet { '20.20.20.3/24':
  ensure    => 'present',
  ctrl      => 'nd',
  descr     => 'My subnet subnet1 in bridge domain test_bd1 in tenant test_tenant1',
  preferred => 'no',
  scope     => 'private',
  virtual   => 'no',
}
```

**2) Make absent, then present and check idempotence.

```puppet
root@proxyagent:~# 
root@proxyagent:~# puppet device --verbose
Initiating authentication with APIC
Info: starting applying configuration to apic.example.com at https://apic.example.com:443
Info: Using configured environment 'production'
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Retrieving locales
Info: Caching catalog for apic.example.com
Info: Applying configuration version '1525372177'
Notice: /Stage[main]/Main/Node[apic.example.com]/Cisco_aci_fvsubnet[subnet1]/ensure: removed
Notice: Cisco_aci_fvsubnet[subnet1](provider=cisco_aci): APIC GUI URI for provisioned resource https://apic.example.com/#bTenants:test_tenant1|uni/tn-test_tenant1/BD-test_bd1/subnet-[20.20.20.3/24]
Notice: /Stage[main]/Main/Node[apic.example.com]/Cisco_aci_vzsubj[test_subject1]/ensure: created
Changed 'cons_match_t' from= '' to= 'AtleastOne' 
Changed 'descr' from= '' to= 'My subject test_subject1 for contract test_contract1 in tenant test_tenant1' 
Changed 'dn' from= '' to= 'uni/tn-test_tenant1/brc-test_contract1/subj-test_subject1' 
Changed 'name' from= '' to= 'test_subject1' 
Changed 'name_alias' from= '' to= '' 
Changed 'prio' from= '' to= 'unspecified' 
Changed 'prov_match_t' from= '' to= 'AtleastOne' 
Changed 'rev_flt_ports' from= '' to= 'yes' 
Changed 'target_dscp' from= '' to= 'unspecified' 
Changed 'fvtenant' from= '' to= 'test_tenant1' 
Changed 'vzbrcp' from= '' to= 'test_contract1' 
Notice: Cisco_aci_vzsubj[test_subject1](provider=cisco_aci): APIC GUI URI for provisioned resource https://apic.example.com/#bTenants:test_tenant1|uni/tn-test_tenant1/brc-test_contract1/subj-[test_subject1]
Info: Node[apic.example.com]: Unscheduling all events on Node[apic.example.com]
Notice: Applied catalog in 3.54 seconds
root@proxyagent:~# 
root@proxyagent:~# puppet device --target apic.example.com --resource cisco_aci_fvsubnet '20.20.20.3/24'
Initiating authentication with APIC
cisco_aci_fvsubnet { '20.20.20.3/24':
  ensure => 'absent',
}
root@proxyagent:~# 
root@proxyagent:~# 
root@proxyagent:~# puppet device --verbose
Initiating authentication with APIC
Info: starting applying configuration to apic.example.com at https://apic.example.com:443
Info: Using configured environment 'production'
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Retrieving locales
Info: Caching catalog for apic.example.com
Info: Applying configuration version '1525372215'
Notice: /Stage[main]/Main/Node[apic.example.com]/Cisco_aci_fvsubnet[subnet1]/ensure: created
Changed 'ctrl' from= '' to= 'nd' 
Changed 'descr' from= '' to= 'My subnet subnet1 in bridge domain test_bd1 in tenant test_tenant1' 
Changed 'dn' from= '' to= 'uni/tn-test_tenant1/BD-test_bd1/subnet-[20.20.20.3/24]' 
Changed 'ip' from= '' to= '20.20.20.3/24' 
Changed 'name_alias' from= '' to= '' 
Changed 'preferred' from= '' to= 'no' 
Changed 'scope' from= '' to= 'private' 
Changed 'virtual' from= '' to= 'no' 
Changed 'fvtenant' from= '' to= 'test_tenant1' 
Changed 'fvbd' from= '' to= 'test_bd1' 
Notice: Cisco_aci_fvsubnet[subnet1](provider=cisco_aci): APIC GUI URI for provisioned resource https://apic.example.com/#bTenants:test_tenant1|uni/tn-test_tenant1/BD-test_bd1/subnet-[20.20.20.3/24]
Info: Node[apic.example.com]: Unscheduling all events on Node[apic.example.com]
Notice: Applied catalog in 2.32 seconds
root@proxyagent:~# 
root@proxyagent:~# 
root@proxyagent:~# puppet device --verbose
Initiating authentication with APIC
Info: starting applying configuration to apic.example.com at https://apic.example.com:443
Info: Using configured environment 'production'
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Retrieving locales
Info: Caching catalog for apic.example.com
Info: Applying configuration version '1525372223'
Notice: Applied catalog in 1.12 seconds
root@proxyagent:~# 
root@proxyagent:~# puppet device --target apic.example.com --resource cisco_aci_fvsubnet '20.20.20.3/24'
Initiating authentication with APIC
cisco_aci_fvsubnet { '20.20.20.3/24':
  ensure    => 'present',
  ctrl      => 'nd',
  descr     => 'My subnet subnet1 in bridge domain test_bd1 in tenant test_tenant1',
  preferred => 'no',
  scope     => 'private',
  virtual   => 'no',
}
root@proxyagent:~# 
```