### PR TITLE
(maint) add patch package for CentOS install class

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -9,7 +9,7 @@ class cisco_aci::install {
 
   case $::operatingsystem {
     'CentOS': {
-      $packages = [ 'gcc', 'zlib-devel' ]
+      $packages = [ 'gcc', 'patch', 'zlib-devel' ]
 
       package { $packages:
         ensure  => present,


### PR DESCRIPTION
Minimal CentOS 7 installs do not include the patch binary which is required for nokogiri installation