### PR TITLE
(maint) fact keys as strings

### DIFF
--- a/lib/puppet_x/cisco/aci_provider_utils.rb
+++ b/lib/puppet_x/cisco/aci_provider_utils.rb
@@ -303,7 +303,7 @@ module PuppetX
           fab_mem_attrs << mem_attrs if mem_attrs
         end
         # Construct the custom ACI Fact Hash
-        { 'aci_fabric_members': fab_mem_attrs }
+        { 'aci_fabric_members' => fab_mem_attrs }
       end
     end
   end


### PR DESCRIPTION
puppet device --apply does not support fact keys as symbols.
This was broken as part of a rubocop cleanup

This was originally fixed by #3 

